### PR TITLE
[47기 양회진] 메인 슬라이드 이미지 구현

### DIFF
--- a/public/data/mainStore.json
+++ b/public/data/mainStore.json
@@ -2,11 +2,19 @@
   {
     "storeId": 1,
     "storeName": "찌니네 반찬가게",
-    "storeImg": "./images/store1.jpeg"
+    "images": [
+      { "id": 1, "image": "/images/food1.jpg" },
+      { "id": 2, "image": "/images/food2.jpg" },
+      { "id": 3, "image": "/images/food3.jpg" }
+    ]
   },
   {
     "storeId": 2,
     "storeName": "lina's hamberger",
-    "storeImg": "./images/store2.JPG"
+    "images": [
+      { "id": 1, "image": "/images/food1.jpg" },
+      { "id": 2, "image": "/images/food2.jpg" },
+      { "id": 3, "image": "/images/food3.jpg" }
+    ]
   }
 ]

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_JS_KEY%&libraries=services,clusterer,drawing"
+    ></script>
     <title>IIIIEE</title>
   </head>
   <body>

--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -120,7 +120,7 @@ const Img = styled.img`
 
 const ListBox = styled.ul`
   position: absolute;
-  top: -10.1em;
+  top: -10em;
   right: 0;
   display: flex;
   justify-content: center;

--- a/src/components/Slide/Slide.jsx
+++ b/src/components/Slide/Slide.jsx
@@ -17,9 +17,13 @@ const Slide = ({ RestaurantInfoData }) => {
     slidesToShow: 1,
     slidesToScroll: 1,
   };
+
+  const getPathname = window.location.pathname;
+  const mainPath = getPathname === '/';
+
   return (
     <Style.Slide>
-      <CustomSlider {...settings}>
+      <CustomSlider {...settings} mainPath={mainPath}>
         {RestaurantInfoData?.images &&
           RestaurantInfoData?.images.map(info => (
             <div key={info.id}>
@@ -39,5 +43,8 @@ const CustomSlider = styled(Slider)`
   }
   .slick-next {
     display: none !important;
+  }
+  .slick-dots {
+    display: ${props => props.mainPath && 'none !important'};
   }
 `;

--- a/src/pages/Gathering/GatheringStyle.jsx
+++ b/src/pages/Gathering/GatheringStyle.jsx
@@ -4,7 +4,7 @@ const Style = {
   Full: styled.div`
     display: flex;
     flex-direction: column;
-    padding: 150px 1em 1em 1em;
+    padding: 75px 1em 1em 1em;
     gap: 20px;
   `,
 

--- a/src/pages/GestList/GestListStyle.js
+++ b/src/pages/GestList/GestListStyle.js
@@ -4,7 +4,7 @@ export const GestListStyle = {
   GestListBox: styled.div`
     display: flex;
     flex-direction: column;
-    padding: 130px 1em 1em 1em;
+    padding: 75px 1em 1em 1em;
   `,
 
   Container: styled.div`

--- a/src/pages/HostList/HostListStyle.js
+++ b/src/pages/HostList/HostListStyle.js
@@ -4,7 +4,7 @@ const HostListStyle = {
   Full: styled.div`
     display: flex;
     flex-direction: column;
-    padding: 150px 1em 1em 1em;
+    padding: 75px 1em 1em 1em;
     gap: 1.5em;
   `,
   Container: styled.div`

--- a/src/pages/Main.js
+++ b/src/pages/Main.js
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
+import Slide from '../components/Slide/Slide';
 
 const Main = () => {
   const [gatheringDatas, setGatheringData] = useState([]);
@@ -30,7 +31,7 @@ const Main = () => {
 
   return (
     <Full>
-      {storeDatas.map(storeData => {
+      {storeDatas.map((storeData, idx) => {
         return (
           <div key={storeData.storeId}>
             <StoreMain
@@ -39,7 +40,7 @@ const Main = () => {
                 handleModal(storeData.storeId);
               }}
             >
-              <StoreImg alt="storeImg" src={storeData.storeImg} />
+              <SlideStyle RestaurantInfoData={storeDatas[idx]} />
               <StoreName>
                 <NameColor>{storeData.storeName}</NameColor>
               </StoreName>
@@ -76,15 +77,15 @@ export default Main;
 const Full = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 150px 1em 1em 1em;
+  padding: 130px 1em 1em 1em;
 `;
 
 const StoreMain = styled.div`
   position: relative;
 `;
 
-const StoreImg = styled.img`
-  width: 100%;
+const SlideStyle = styled(Slide)`
+  position: relative;
 `;
 
 const StoreBtn = styled.button`
@@ -100,7 +101,7 @@ const StoreName = styled.p`
   background-color: rgba(0, 0, 0, 0.45);
   height: 3em;
   position: absolute;
-  top: 78%;
+  bottom: 1%;
   width: 100%;
   line-height: 3.2em;
 `;

--- a/src/pages/Registration.js
+++ b/src/pages/Registration.js
@@ -243,7 +243,7 @@ const Registration = () => {
 export default Registration;
 
 const Full = styled.div`
-  padding: 150px 1em 1em 1em;
+  padding: 75px 1em 1em 1em;
   display: flex;
   flex-direction: column;
   gap: 1em;

--- a/src/pages/RestaurantInfo/RestaurantInfoStyle.js
+++ b/src/pages/RestaurantInfo/RestaurantInfoStyle.js
@@ -3,7 +3,7 @@ import { styled } from 'styled-components';
 export const Style = {
   RestaurantInfoBox: styled.div`
     height: 100vh;
-    padding: 130px 1em 71px;
+    padding: 60px 1em 1em 1em;
     overflow: scroll;
   `,
   Img: styled.img`


### PR DESCRIPTION
슬라이드 컴포넌트에 맞춰 데이터 보내줌
메인 페이지에서는 버튼 안 보이도록 구현

<img width="529" alt="스크린샷 2023-07-21 오전 11 59 11" src="https://github.com/wecode-bootcamp-korea/47-2nd-IIIIEE-frontend/assets/125977702/13536736-b7d0-4ab9-9cc9-309f60316d25">

window.location.pathname
슬라이드 라이브러리