### PR TITLE
[47기 양회진] 카카오페이 결제 api 연결

### DIFF
--- a/public/data/listData.json
+++ b/public/data/listData.json
@@ -11,6 +11,7 @@
       "roomDay": "20",
       "hour": "14:00",
       "price": 80000,
+      "roomStatue": 1,
       "guests": [
         { "id": 1, "name": "하대리" },
         { "id": 2, "name": "이주현" }

--- a/src/Router.js
+++ b/src/Router.js
@@ -8,6 +8,8 @@ import RestaurantInfo from './pages/RestaurantInfo/RestaurantInfo';
 import HoseList from './pages/HostList/HoseList';
 import KakaoLogin from './components/Nav/KakaoLogin';
 import GestList from './pages/GestList/GestList';
+import PayFail from './pages/HostList/PayFail';
+import KakaoPay from './pages/HostList/KakaoPay';
 import NotFound from './pages/NotFound/NotFound';
 
 const Router = () => {
@@ -22,6 +24,8 @@ const Router = () => {
           <Route path="hostList" element={<HoseList />} />
           <Route path="kakakoLogin" element={<KakaoLogin />} />
           <Route path="gestlist" element={<GestList />} />
+          <Route path="payFail" element={<PayFail />} />
+          <Route path="kakaopay" element={<KakaoPay />} />
         </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/src/pages/Gathering/Gathering.js
+++ b/src/pages/Gathering/Gathering.js
@@ -10,6 +10,7 @@ const Gathering = () => {
   const token = localStorage.getItem('token');
   const [textData, setTextData] = useState({});
   const {
+    roomId,
     roomTitle,
     roomImage,
     price,
@@ -33,7 +34,7 @@ const Gathering = () => {
   }, []);
 
   const applyToGathering = () => {
-    fetch('http://52.78.25.104:3000/rooms', {
+    fetch(`http://52.78.25.104:3000/rooms/${roomId}/join`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/pages/Gathering/Host.js
+++ b/src/pages/Gathering/Host.js
@@ -33,7 +33,7 @@ const Host = ({ textData }) => {
     //   alert('글을 입력 후 클릭해주세요.');
     // }
 
-    fetch('http://52.78.25.104:3000/review/host/:userId', {
+    fetch(`http://52.78.25.104:3000/review/host/${gatheringData.id}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/pages/HostList/HoseList.js
+++ b/src/pages/HostList/HoseList.js
@@ -3,6 +3,8 @@ import HostListStyle from './HostListStyle';
 
 const HoseList = () => {
   const [listData, setListData] = useState([]);
+  const REACT_APP_SERVICE_APP_ADMIN_KEY =
+    process.env.REACT_APP_SERVICE_APP_ADMIN_KEY;
   // const token = localStorage.getItem('token');
 
   useEffect(() => {
@@ -18,9 +20,40 @@ const HoseList = () => {
       .then(result => setListData(result.data));
   }, []);
 
+  const goToPay = idx => {
+    fetch(`https://kapi.kakao.com/v1/payment/ready`, {
+      method: 'POST',
+      body: new URLSearchParams({
+        cid: 'TC0ONETIME',
+        partner_order_id: listData[idx]?.roomId,
+        partner_user_id: 'token',
+        item_name: listData[idx]?.roomTitle,
+        quantity: 1,
+        total_amount: listData[idx]?.price,
+        tax_free_amount: 0,
+        approval_url: `http://localhost:3000/kakaopay?partner_order_id=${listData[idx]?.roomId}`,
+        cancel_url: 'http://localhost:3000/payFail',
+        fail_url: 'http://localhost:3000/payFail',
+      }).toString(),
+      headers: {
+        'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+        Authorization: `KakaoAK ${REACT_APP_SERVICE_APP_ADMIN_KEY}`,
+      },
+    })
+      .then(response => {
+        return response.json();
+      })
+      .then(data => {
+        if (data.tid) {
+          localStorage.setItem('tid', data.tid);
+          window.location.href = data.next_redirect_pc_url;
+        }
+      });
+  };
+
   return (
     <HostListStyle.Full>
-      {listData.map(list => {
+      {listData.map((list, idx) => {
         const {
           roomId,
           roomTitle,
@@ -30,6 +63,7 @@ const HoseList = () => {
           roomYear,
           roomMonth,
           roomDay,
+          roomStatue,
         } = list;
         return (
           <HostListStyle.Container key={roomId}>
@@ -53,10 +87,14 @@ const HoseList = () => {
               );
             })}
 
-            <HostListStyle.RegistrationBtn>
-              예약하기
-            </HostListStyle.RegistrationBtn>
-            <HostListStyle.Complete>예약완료</HostListStyle.Complete>
+            {roomStatue !== 3 && (
+              <HostListStyle.RegistrationBtn onClick={() => goToPay(idx)}>
+                예약하기
+              </HostListStyle.RegistrationBtn>
+            )}
+            {roomStatue === 3 && (
+              <HostListStyle.Complete>예약완료</HostListStyle.Complete>
+            )}
           </HostListStyle.Container>
         );
       })}

--- a/src/pages/HostList/KakaoPay.js
+++ b/src/pages/HostList/KakaoPay.js
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const KakaoPay = () => {
+  const navigate = useNavigate();
+  const pg_token = new URL(document.location).searchParams.get('pg_token');
+  const partner_order_id = new URL(document.location).searchParams.get(
+    'partner_order_id',
+  );
+  const token = localStorage.getItem('token');
+
+  const postData = {
+    cid: 'TC0ONETIME',
+    tid: localStorage.getItem('tid'),
+    partner_order_id,
+    partner_user_id: 'token',
+    pg_token,
+  };
+
+  useEffect(() => {
+    fetch(`https://kapi.kakao.com/v1/payment/approve`, {
+      method: 'POST',
+      headers: {
+        'Content-type': 'application/x-www-form-urlencoded;charset=utf-8',
+        Authorization: `KakaoAK ${process.env.REACT_APP_SERVICE_APP_ADMIN_KEY}`,
+      },
+      body: new URLSearchParams(postData).toString(),
+    })
+      .then(response => response.json())
+      .then(data => {
+        if (data.approved_at) {
+          // acceptPay();
+          navigate('hostList');
+        } else if (data.code === '-780') {
+          alert('진행중인 거래가 있습니다. 잠시 후 다시 시도해 주세요.');
+        }
+      });
+  }, []);
+
+  const acceptPay = () => {
+    fetch(`https://kapi.kakao.com/v1/payment/approve`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        tid: localStorage.getItem('tid'),
+        pg_token,
+      }),
+    })
+      .then(response => response.json())
+      .then(data => {
+        if (data.approved_at) {
+          navigate('/hostlist');
+          localStorage.removeItem('tid');
+        } else if (data.code === '-780') {
+          alert('진행중인 거래가 있습니다. 잠시 후 다시 시도해 주세요.');
+        }
+      });
+  };
+
+  return <div>KakaoPay</div>;
+};
+
+export default KakaoPay;

--- a/src/pages/HostList/PayFail.js
+++ b/src/pages/HostList/PayFail.js
@@ -1,0 +1,22 @@
+import { useNavigate } from 'react-router-dom';
+import style from './PayFailStyle';
+
+const PayFail = () => {
+  const navigate = useNavigate();
+
+  const goToList = () => {
+    navigate('/hostList');
+  };
+  return (
+    <style.Full>
+      <img alt="logo" src="./images/logo.png" />
+      <div>
+        <p>죄송합니다. </p>
+        <p>결제가 취소되거나 실패되었습니다.</p>
+      </div>
+      <button onClick={goToList}>다시 결제하러 가기</button>
+    </style.Full>
+  );
+};
+
+export default PayFail;

--- a/src/pages/HostList/PayFailStyle.jsx
+++ b/src/pages/HostList/PayFailStyle.jsx
@@ -1,0 +1,37 @@
+import { styled } from 'styled-components';
+
+const style = {
+  Full: styled.div`
+    padding: 80px 1em 110px 1em;
+    display: flex;
+    flex-direction: column;
+    gap: 2em;
+    div {
+      display: flex;
+      flex-direction: column;
+      gap: 1em;
+      p {
+        text-align: center;
+        font-size: 1.5em;
+      }
+    }
+
+    button {
+      cursor: pointer;
+      width: 100%;
+      height: 4em;
+      padding: 0.5em;
+      border: 0;
+      border-radius: 1em;
+      background: ${props => props.theme.mainColor};
+      color: white;
+      &:hover {
+        background: #fff;
+        color: ${props => props.theme.mainColor};
+        border: 1px solid ${props => props.theme.mainColor};
+      }
+    }
+  `,
+};
+
+export default style;


### PR DESCRIPTION
## 1. 해당 브랜치에서 작업한 내용
- 카카오페이 결제 api 연결

## 2. 작업한 결과물
![iiiee 결제 api 사용](https://github.com/wecode-bootcamp-korea/47-2nd-IIIIEE-frontend/assets/125977702/a245fe45-2bd8-47b9-b35a-36241ccd2328)

## 3. 해당 작업을 하면서 생겼던 이슈사항
1. 기존에는 카카오페이 결제 로직이 카카오와의 2회 통신을 필요로 했으며, 프로젝트 기획 단계에서는 이를 모두 프론트엔드에서 처리하기로 결정
- 백엔드가 중간 과정 없이 결과만 받는 것에 아쉬워해  첫 번째 통신만 프론트엔드가 작업을 수행하고 그 결과를 백엔드에게 전달하는 방식으로 변경
- 이 과정을 통해 기존에는 카카오와의 2번 백엔드와 1번 총 세 번의 통신이 필요했던 로직을 중간에 tid와 pgToken을 백엔드에게 전달하는 로직으로 변경함. 통신 횟수를 총 2회로 줄여 프론트, 백엔드 모두 결제 경험을 가져갈 수 있도록 효율성을 극대화

## 4. 해당 작업을 통해 알게 된 내용
- 모두 프론트에서 작업을 할 수 있었지만 백엔드의 로직도 사용함으로써 우리 프로젝트의 전반적인 로직의 사용성을 높일 수 있었던 것